### PR TITLE
P/reportload

### DIFF
--- a/components/WindowMenu.qml
+++ b/components/WindowMenu.qml
@@ -74,21 +74,63 @@ Rectangle {
                 Layout.alignment: Qt.AlignVCenter
 
                 // App Version
-                Text {
-                    text: "APP: "+windowMenu.appVerText
-                    color: "#AAAAAA"
-                    font.pixelSize: 12
-                    font.weight: Font.Medium
-                    horizontalAlignment: Text.AlignRight
+                RowLayout {
+                    spacing: 0
+                    Layout.alignment: Qt.AlignLeft
+                    
+                    Text {
+                        text: "APP: v"
+                        color: "#AAAAAA"
+                        font.pixelSize: 12
+                        font.weight: Font.Medium
+                    }
+                    
+                    TextField {
+                        text: windowMenu.appVerText
+                        color: "#AAAAAA"
+                        font.pixelSize: 12
+                        font.weight: Font.Medium
+                        readOnly: true
+                        selectByMouse: true
+                        leftPadding: 0
+                        rightPadding: 0
+                        topPadding: 0
+                        bottomPadding: 0
+                        background: Rectangle {
+                            color: "transparent"
+                            border.color: "transparent"
+                        }
+                    }
                 }
 
                 // SDK Version
-                Text {
-                    text: "SDK: "+windowMenu.sdkVerText
-                    color: "#AAAAAA"
-                    font.pixelSize: 12
-                    font.weight: Font.Medium
-                    horizontalAlignment: Text.AlignRight
+                RowLayout {
+                    spacing: 0
+                    Layout.alignment: Qt.AlignLeft
+                    
+                    Text {
+                        text: "SDK: v"
+                        color: "#AAAAAA"
+                        font.pixelSize: 12
+                        font.weight: Font.Medium
+                    }
+                    
+                    TextField {
+                        text: windowMenu.sdkVerText
+                        color: "#AAAAAA"
+                        font.pixelSize: 12
+                        font.weight: Font.Medium
+                        readOnly: true
+                        selectByMouse: true
+                        leftPadding: 0
+                        rightPadding: 0
+                        topPadding: 0
+                        bottomPadding: 0
+                        background: Rectangle {
+                            color: "transparent"
+                            border.color: "transparent"
+                        }
+                    }
                 }
             }
         }

--- a/lifu_connector.py
+++ b/lifu_connector.py
@@ -8,7 +8,8 @@ import numpy as np
 import re
 import base58
 import json
-from scripts.generate_ultrasound_plot import generate_ultrasound_plot  # Import the function directly
+from scripts.generate_ultrasound_plot import generate_ultrasound_plot  # Import the function directly\nfrom scripts.test_reports import read_test_report, test_report_to_config, check_config_against_device
+from scripts.test_reports import read_test_report, test_report_to_config, check_config_against_device
 from openlifu_sdk.io import LIFUInterface
 
 logger = logging.getLogger("LIFUConnector")
@@ -86,6 +87,7 @@ class LIFUConnector(QObject):
     solutionFileLoaded = pyqtSignal(str, str)  # (solution_name, message)
     solutionLoadError = pyqtSignal(str)  # (error_message)
     solutionStateChanged = pyqtSignal()  # Notifies when solution is loaded/unloaded
+    testReportLoaded = pyqtSignal(bool, str)  # (success, message)
 
     def __init__(self, hv_test_mode=False):
         super().__init__()
@@ -1321,11 +1323,65 @@ class LIFUConnector(QObject):
             self.solutionStateChanged.emit()
             logger.info(f"Released solution '{solution_name}' - UI fields preserved, controls are now editable")
     
-    @pyqtSlot()
-    def clearLoadedSolution(self):
-        """Clear the currently loaded solution and return controls to editable state."""
-        self._solution_loaded = False
-        self._loaded_solution_data = None
-        self._solution_name = ""
-        self.solutionStateChanged.emit()
-        logger.info("Solution cleared - controls returned to editable state")
+    @pyqtSlot(str, str)
+    def loadTestReport(self, file_path, target):
+        """Load and validate test report against specified TXM module"""
+        def _run():
+            try:
+                # Parse the target to get module number
+                module = _parse_tx_module(target)
+                if module is None:
+                    self.testReportLoaded.emit(False, f"Unsupported target: {target}")
+                    return
+                
+                # Convert file URL to local path
+                if file_path.startswith("file:///"):
+                    file_path_clean = file_path[8:]  # Remove file:/// prefix
+                elif file_path.startswith("file://"):
+                    file_path_clean = file_path[7:]  # Remove file:// prefix
+                else:
+                    file_path_clean = file_path
+                    
+                logger.info(f"Loading test report from: {file_path_clean} for {target}")
+                
+                # Read the test report
+                report_df = read_test_report(file_path_clean)
+                config = test_report_to_config(report_df)
+                
+                # Extract report information
+                report_sn = config.get('sn', 'Unknown')
+                report_hwid = config.get('hwid', 'Unknown')
+                report_freq = config.get('freq', 'Unknown')
+                
+                report_info = f"SN: {report_sn}, HWID: {report_hwid}, Freq: {report_freq} kHz"
+                
+                # Check if we have a connected TXM to compare against
+                if self._txConnected:
+                    try:
+                        # Check against specified module
+                        check_result = check_config_against_device(self.interface, config, module=module)
+                        if check_result is not False:  # None means warnings but valid, False means mismatch
+                            # Convert config to JSON string and populate User Config editor
+                            import json
+                            json_str = json.dumps(config, indent=2)
+                            self.userConfigRead.emit(target, json_str)
+                            
+                            message = f"Test report matches {target}! {report_info} - Config loaded into editor."
+                            self.testReportLoaded.emit(True, message)
+                        else:
+                            message = f"Test report does NOT match {target}. Report: {report_info}"
+                            self.testReportLoaded.emit(False, message)
+                    except Exception as e:
+                        logger.warning(f"Could not verify report against device: {e}")
+                        message = f"Test report loaded but could not verify against {target}: {e}"
+                        self.testReportLoaded.emit(False, message)
+                else:
+                    message = f"Test report loaded. No TXM connected for verification. {report_info}"
+                    self.testReportLoaded.emit(False, message)
+                    
+            except Exception as e:
+                error_msg = f"Failed to load test report: {str(e)}"
+                logger.error(error_msg)
+                self.testReportLoaded.emit(False, error_msg)
+                
+        threading.Thread(target=_run, daemon=True).start()

--- a/main.qml
+++ b/main.qml
@@ -37,8 +37,8 @@ Window {
             // Set title and logo dynamically
             titleText: "Open-LIFU Engineering App"
             logoSource: "../assets/images/OpenwaterLogo.png" // Correct relative path
-            appVerText: "v" + appVersion
-            sdkVerText: "v" + LIFUConnector.sdkVersion
+            appVerText: appVersion
+            sdkVerText: LIFUConnector.sdkVersion
         }
 
         // Layout for Sidebar and Main Content

--- a/pages/Demo.qml
+++ b/pages/Demo.qml
@@ -14,6 +14,12 @@ Rectangle {
     // Properties to track solution loading state
     property bool solutionLoaded: LIFUConnector.solutionLoaded
     property bool controlsReadOnly: solutionLoaded || LIFUConnector.state >= 2
+    property var txTemperatures: []
+    property real hvPositiveRail: NaN
+    property real hvNegativeRail: NaN
+    property string statusOverrideText: ""
+    property int configuredModuleCount: 0
+    property int previousConnectorState: LIFUConnector.state
     
     // Properties to track field activity based on trigger mode
     property bool pulseIntervalActive: true
@@ -49,6 +55,72 @@ Rectangle {
                             : LIFUConnector.state === 2 ? "Configured"
                             : LIFUConnector.state === 3 ? "Ready"
                             : "Running")
+    }
+
+    function getTxTemperatureText() {
+        if (!LIFUConnector.txConnected) {
+            return "Temp [--.-]"
+        }
+
+        let displayCount = Math.max(configuredModuleCount, txTemperatures.length)
+        if (displayCount === 0) {
+            return "Temp [--.-]"
+        }
+
+        let displayValues = []
+        for (let index = 0; index < displayCount; index++) {
+            let temp = txTemperatures[index]
+            displayValues.push(typeof temp === "number" && !isNaN(temp) ? temp.toFixed(1) : "--")
+        }
+
+        return "Temp [" + displayValues.join(", ") + "] C"
+    }
+
+    function getHvRailText() {
+        if (!LIFUConnector.hvConnected || isNaN(hvPositiveRail) || isNaN(hvNegativeRail)) {
+            return "Rails +--.-- / ----.-- V"
+        }
+
+        return "Rails +" + hvPositiveRail.toFixed(2) + " / -" + Math.abs(hvNegativeRail).toFixed(2) + " V"
+    }
+
+    function refreshStatusTelemetry() {
+        if (LIFUConnector.txConnected) {
+            if (configuredModuleCount <= 0) {
+                LIFUConnector.queryNumModules()
+            }
+            LIFUConnector.queryTxTemperature()
+        }
+
+        if (LIFUConnector.hvConnected) {
+            LIFUConnector.getMonitorVoltages()
+        }
+    }
+
+    function clearStatusTelemetry() {
+        txTemperatures = []
+        hvPositiveRail = NaN
+        hvNegativeRail = NaN
+    }
+
+    function getIndicatorColor(isConnected) {
+        if (!isConnected) {
+            return "#C0392B"
+        }
+
+        if (LIFUConnector.state === 4) {
+            return "#43bb57"
+        }
+
+        if (LIFUConnector.state === 1) {
+            return "#5BC0EB"
+        }
+
+        if (LIFUConnector.state === 2 || LIFUConnector.state === 3) {
+            return "#31aa63"
+        }
+
+        return "#5BC0EB"
     }
 
     // File dialog for loading solutions
@@ -429,7 +501,7 @@ Rectangle {
                     Button {
                         text: "Edit Solution"
                         Layout.fillWidth: true
-                        enabled: controlsReadOnly
+                        enabled: controlsReadOnly && (LIFUConnector.state <4)
                         background: Rectangle {
                             color: "#2E86AB"
                             radius: 4
@@ -438,7 +510,7 @@ Rectangle {
                         onClicked: {
                             LIFUConnector.reset_configuration()
                             LIFUConnector.makeLoadedSolutionEditable()
-                            statusText.text = getSystemStateText()
+                            statusOverrideText = ""
                         }
                     }
 
@@ -458,12 +530,13 @@ Rectangle {
                                 zInput.text,  frequencyInput.text, voltage.text, triggerPulseInterval.text, triggerPulseCount.text, 
                                 triggerPulseTrainInterval.text, triggerPulseTrainCount.text, durationInput.text, 
                                 triggerModeDropdown.currentText);
+                            configuredModuleCount = LIFUConnector.queryNumModulesConnected
                             LIFUConnector.generate_plot(
                                  xInput.text, yInput.text, zInput.text,
                                  frequencyInput.text, "100", frequency,
                                  "buffer"
                             );
-                            statusText.text = getSystemStateText()
+                            statusOverrideText = ""
                         }
                     }
                 }
@@ -501,6 +574,7 @@ Rectangle {
                         }
                         onClicked: {
                             console.log("Stopping Sonication...");
+                            clearStatusTelemetry()
                             LIFUConnector.stop_sonication();
                             // LIFUConnector.setAsyncMode(false)
                         }
@@ -674,7 +748,7 @@ Rectangle {
             Rectangle {
                 id: statusPanel
                 width: 500
-                height: 130
+                height: 170
                 color: "#252525"
                 radius: 10
                 border.color: "#3E4E6F"
@@ -687,11 +761,17 @@ Rectangle {
                     // Connection status text
                     Text {
                         id: statusText
-                        text: getSystemStateText()
+                        text: statusOverrideText !== "" ? statusOverrideText : getSystemStateText()
                         font.pixelSize: 16
-                        color: "#BDC3C7"
+                        color: getIndicatorColor(LIFUConnector.txConnected && LIFUConnector.hvConnected)
                         horizontalAlignment: Text.AlignHCenter
                         anchors.horizontalCenter: parent.horizontalCenter
+                        SequentialAnimation on opacity {
+                            running: LIFUConnector.state === 4
+                            loops: Animation.Infinite
+                            NumberAnimation { from: 1.0; to: 0.35; duration: 500 }
+                            NumberAnimation { from: 0.35; to: 1.0; duration: 500 }
+                        }
                     }
 
                     // Connection Indicators (TX, HV)
@@ -704,10 +784,11 @@ Rectangle {
                             spacing: 5
                             // LED circle
                             Rectangle {
+                                id: txIndicator
                                 width: 20
                                 height: 20
                                 radius: 10
-                                color: LIFUConnector.txConnected ? "green" : "red"
+                                color: getIndicatorColor(LIFUConnector.txConnected)
                                 border.color: "black"
                                 border.width: 1
                             }
@@ -718,6 +799,13 @@ Rectangle {
                                 color: "#BDC3C7"
                                 verticalAlignment: Text.AlignVCenter
                             }
+
+                            Text {
+                                text: getTxTemperatureText()
+                                font.pixelSize: 12
+                                color: "#9FB3C8"
+                                verticalAlignment: Text.AlignVCenter
+                            }
                         }
 
                         // HV LED
@@ -725,10 +813,11 @@ Rectangle {
                             spacing: 5
                             // LED circle
                             Rectangle {
+                                id: hvIndicator
                                 width: 20
                                 height: 20
                                 radius: 10
-                                color: LIFUConnector.hvConnected ? "green" : "red"
+                                color: getIndicatorColor(LIFUConnector.hvConnected)
                                 border.color: "black"
                                 border.width: 1
                             }
@@ -737,6 +826,13 @@ Rectangle {
                                 text: "HV"
                                 font.pixelSize: 16
                                 color: "#BDC3C7"
+                                verticalAlignment: Text.AlignVCenter
+                            }
+
+                            Text {
+                                text: getHvRailText()
+                                font.pixelSize: 12
+                                color: "#9FB3C8"
                                 verticalAlignment: Text.AlignVCenter
                             }
                         }
@@ -758,33 +854,46 @@ Rectangle {
         }
     }
 
+    Timer {
+        id: telemetryPollTimer
+        interval: 1000
+        repeat: true
+        running: LIFUConnector.state === 4
+        onTriggered: {
+            refreshStatusTelemetry()
+        }
+    }
+
     // **Connections for LIFUConnector signals**
     Connections {
         target: LIFUConnector
 
         function onSignalConnected(descriptor, port) {
             console.log(descriptor + " connected on " + port);
-            statusText.text = "Connected: " + descriptor + " on " + port;
+            statusOverrideText = ""
         }
 
         function onSignalDisconnected(descriptor, port) {
             console.log(descriptor + " disconnected from " + port);
-            statusText.text = "Disconnected: " + descriptor + " from " + port;
+            if (descriptor === "TX") {
+                txTemperatures = [];
+                configuredModuleCount = 0;
+            }
+            if (descriptor === "HV") {
+                hvPositiveRail = NaN;
+                hvNegativeRail = NaN;
+            }
+            statusOverrideText = ""
         }
 
         function onSignalDataReceived(descriptor, message) {
             console.log("Data from " + descriptor + ": " + message);
         }
 
-        function onTriggerStateChanged(state) {
-            triggerStatus.text = state ? "On" : "Off";
-            triggerStatus.color = state ? "green" : "red";
-        }
-
         function onPlotGenerated(imageData) {
             console.log("Received image data for display.");
             ultrasoundGraph.updateImage("data:image/png;base64," + imageData);
-            statusText.text = "Status: Plot updated!";
+            statusOverrideText = "";
         }
 
         // Solution loading signal handlers
@@ -792,27 +901,57 @@ Rectangle {
             console.log("Solution loaded: " + solutionName + " - " + message);
             LIFUConnector.reset_configuration();
             applySolutionSettings();
-            statusText.text = getSystemStateText();
+            statusOverrideText = "";
         }
 
         function onSolutionLoadError(errorMessage) {
             console.error("Solution load error: " + errorMessage);
-            statusText.text = "Error: " + errorMessage;
+            statusOverrideText = "Error: " + errorMessage;
         }
 
         function onSolutionStateChanged() {
             console.log("Solution state changed - loaded:", LIFUConnector.solutionLoaded);
             if (!LIFUConnector.solutionLoaded) {
-                statusText.text = "Status: Solution cleared - controls are now editable";
+                statusOverrideText = "";
+            }
+        }
+
+        function onTemperatureTxUpdated(module, tx_temp, amb_temp) {
+            let updated = txTemperatures.slice()
+            while (updated.length <= module) {
+                updated.push(NaN)
+            }
+            updated[module] = tx_temp
+            txTemperatures = updated
+        }
+
+        function onNumModulesUpdated() {
+            configuredModuleCount = LIFUConnector.queryNumModulesConnected
+        }
+
+        function onMonVoltagesReceived(voltages) {
+            if (voltages.length >= 4) {
+                hvPositiveRail = voltages[0].converted_voltage
+                hvNegativeRail = voltages[3].converted_voltage
             }
         }
 
         function onStateChanged(state) {
-            statusText.text = getSystemStateText();
+            statusOverrideText = "";
+
+            if (previousConnectorState === 4 && state !== 4) {
+                clearStatusTelemetry();
+            }
+
+            if (state >= 2 && configuredModuleCount <= 0) {
+                configuredModuleCount = LIFUConnector.queryNumModulesConnected
+            }
 
             if (state === 3) {
                 postReadyTimer.start();
             }
+
+            previousConnectorState = state;
         }
     }
 

--- a/pages/Demo.qml
+++ b/pages/Demo.qml
@@ -415,7 +415,7 @@ Rectangle {
                     Button {
                         text: "Load Solution"
                         Layout.fillWidth: true
-                        enabled: !solutionLoaded && LIFUConnector._state <2
+                        enabled: (!solutionLoaded) && (LIFUConnector.state <2)
                         background: Rectangle {
                             color: "#3A3F4B"
                             radius: 4

--- a/pages/Demo.qml
+++ b/pages/Demo.qml
@@ -307,7 +307,7 @@ Rectangle {
                             id: durationInput
                             Layout.preferredHeight: 32
                             font.pixelSize: 14
-                            text: "2e-5"
+                            text: "2e-4"
                             color: controlsReadOnly ? "#BBB" : "white" 
                             enabled: !controlsReadOnly
                             background: Rectangle {

--- a/pages/Demo.qml
+++ b/pages/Demo.qml
@@ -415,7 +415,7 @@ Rectangle {
                     Button {
                         text: "Load Solution"
                         Layout.fillWidth: true
-                        enabled: !solutionLoaded
+                        enabled: !solutionLoaded && LIFUConnector._state <2
                         background: Rectangle {
                             color: "#3A3F4B"
                             radius: 4

--- a/pages/Demo.qml
+++ b/pages/Demo.qml
@@ -13,7 +13,7 @@ Rectangle {
 
     // Properties to track solution loading state
     property bool solutionLoaded: LIFUConnector.solutionLoaded
-    property bool controlsReadOnly: solutionLoaded
+    property bool controlsReadOnly: solutionLoaded || LIFUConnector.state >= 2
     
     // Properties to track field activity based on trigger mode
     property bool pulseIntervalActive: true
@@ -41,6 +41,14 @@ Rectangle {
         }
         
         trainIntervalTooShort = trainInterval < (pulseInterval * pulseCount)
+    }
+
+    function getSystemStateText() {
+        return "System State: " + (LIFUConnector.state === 0 ? "Disconnected"
+                            : LIFUConnector.state === 1 ? "TX Connected, Not Configured"
+                            : LIFUConnector.state === 2 ? "Configured"
+                            : LIFUConnector.state === 3 ? "Ready"
+                            : "Running")
     }
 
     // File dialog for loading solutions
@@ -267,7 +275,7 @@ Rectangle {
 							Layout.preferredHeight: 32
 							model: ["Single", "Continuous", "Sequence"]
                             currentIndex: 1
-							enabled: true
+                            enabled: !controlsReadOnly
 							
 							background: Rectangle {
                                 color: "#222"
@@ -421,21 +429,23 @@ Rectangle {
                     Button {
                         text: "Edit Solution"
                         Layout.fillWidth: true
-                        enabled: solutionLoaded
+                        enabled: controlsReadOnly
                         background: Rectangle {
                             color: "#2E86AB"
                             radius: 4
                             border.color: "#BDC3C7"
                         }
                         onClicked: {
+                            LIFUConnector.reset_configuration()
                             LIFUConnector.makeLoadedSolutionEditable()
+                            statusText.text = getSystemStateText()
                         }
                     }
 
                     Button {
                         text: "Send to Device"
                         Layout.fillWidth: true
-                        enabled: LIFUConnector.state === 1  // TX_CONNECTED
+                        enabled: LIFUConnector.state === 1  // TX connected and not configured
                         background: Rectangle {
                             color: "#3A3F4B"
                             radius: 4
@@ -453,6 +463,7 @@ Rectangle {
                                  frequencyInput.text, "100", frequency,
                                  "buffer"
                             );
+                            statusText.text = getSystemStateText()
                         }
                     }
                 }
@@ -676,11 +687,7 @@ Rectangle {
                     // Connection status text
                     Text {
                         id: statusText
-                        text: "System State: " + (LIFUConnector.state === 0 ? "Disconnected"
-                                        : LIFUConnector.state === 1 ? "TX Connected"
-                                        : LIFUConnector.state === 2 ? "Configured"
-                                        : LIFUConnector.state === 3 ? "Ready"
-                                        : "Running")
+                        text: getSystemStateText()
                         font.pixelSize: 16
                         color: "#BDC3C7"
                         horizontalAlignment: Text.AlignHCenter
@@ -774,12 +781,6 @@ Rectangle {
             triggerStatus.color = state ? "green" : "red";
         }
 
-        function onStateChanged(state) {
-            if (state === 3) {
-                postReadyTimer.start();
-            }
-        }
-
         function onPlotGenerated(imageData) {
             console.log("Received image data for display.");
             ultrasoundGraph.updateImage("data:image/png;base64," + imageData);
@@ -789,8 +790,9 @@ Rectangle {
         // Solution loading signal handlers
         function onSolutionFileLoaded(solutionName, message) {
             console.log("Solution loaded: " + solutionName + " - " + message);
-            statusText.text = "Status: " + message;
+            LIFUConnector.reset_configuration();
             applySolutionSettings();
+            statusText.text = getSystemStateText();
         }
 
         function onSolutionLoadError(errorMessage) {
@@ -802,6 +804,14 @@ Rectangle {
             console.log("Solution state changed - loaded:", LIFUConnector.solutionLoaded);
             if (!LIFUConnector.solutionLoaded) {
                 statusText.text = "Status: Solution cleared - controls are now editable";
+            }
+        }
+
+        function onStateChanged(state) {
+            statusText.text = getSystemStateText();
+
+            if (state === 3) {
+                postReadyTimer.start();
             }
         }
     }

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -19,6 +19,7 @@ Rectangle {
     property int txModuleCount: 0
     property bool txLoading: false
     property var configTargetModel: []
+    property var modules: []  // Device info for all modules
 
     function rebuildConfigTargets() {
         var items = []
@@ -131,6 +132,7 @@ Rectangle {
                 settingsPage.txLoading = false
                 settingsPage.txModuleCount = 0
                 txCurrentVersion.text = "\u2014"
+                modules = []  // Clear device info when disconnected
             }
             rebuildConfigTargets()
         }
@@ -142,6 +144,8 @@ Rectangle {
             if (settingsPage.txModuleCount > 0) {
                 txCurrentVersion.text = "Reading…"
                 LIFUConnector.readTxFirmwareVersion(txModuleSelector.currentIndex)
+                // Also fetch device info for all modules
+                LIFUConnector.queryTxInfo()
             }
             rebuildConfigTargets()
         }
@@ -156,6 +160,24 @@ Rectangle {
             userConfigStatusText.color = success ? "#2ECC71" : "#E74C3C"
             userConfigStatusText.visible = true
             userConfigStatusHideTimer.restart()
+        }
+
+        function onTestReportLoaded(success, message) {
+            // Flash the status text briefly; reuse the editor placeholder area
+            userConfigStatusText.text = message
+            userConfigStatusText.color = success ? "#2ECC71" : "#E74C3C"
+            userConfigStatusText.visible = true
+            userConfigStatusHideTimer.restart()
+        }
+
+        function onTxDeviceInfoReceived(modulesList) {
+            // Store device info for all modules
+            modules = modulesList.map(function(m) {
+                return {
+                    firmwareVersion: m.firmwareVersion,
+                    deviceId: m.deviceId
+                }
+            })
         }
     }
 
@@ -174,6 +196,16 @@ Rectangle {
         title: "Select Transmitter Firmware File"
         nameFilters: ["Signed firmware (*.bin *.signed.bin)", "All files (*)"]
         onAccepted: transmitterFwPath.text = selectedFile.toString().replace("file:///", "")
+    }
+    
+    FileDialog {
+        id: testReportDialog
+        title: "Select Excel Test Report"
+        nameFilters: ["Excel files (*.xlsx *.xls)", "All files (*)"]
+        onAccepted: {
+            var target = configTargetSelector.currentText.toLowerCase()
+            LIFUConnector.loadTestReport(selectedFile, target)
+        }
     }
 
     // ----------------------------------------------------------------
@@ -437,6 +469,65 @@ Rectangle {
                             }
                         }
 
+                        // Device Info for selected target
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+                            visible: configTargetSelector.enabled && configTargetSelector.currentText.startsWith("TX")
+                            
+                            Text { 
+                                text: "Device ID:"
+                                color: "#BDC3C7"
+                                font.pixelSize: 12
+                            }
+                            Text { 
+                                Layout.fillWidth: true
+                                text: {
+                                    if (!configTargetSelector.enabled || !configTargetSelector.currentText.startsWith("TX")) {
+                                        return "N/A"
+                                    }
+                                    // Extract module index from "TX 0", "TX 1", etc.
+                                    var parts = configTargetSelector.currentText.split(" ")
+                                    if (parts.length >= 2) {
+                                        var moduleIndex = parseInt(parts[1])
+                                        return modules[moduleIndex] ? modules[moduleIndex].deviceId : "N/A"
+                                    }
+                                    return "N/A"
+                                }
+                                color: "#3498DB"
+                                font.pixelSize: 12
+                            }
+                        }
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+                            visible: configTargetSelector.enabled && configTargetSelector.currentText.startsWith("TX")
+                            
+                            Text { 
+                                text: "Firmware Version:"
+                                color: "#BDC3C7"
+                                font.pixelSize: 12
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                text: {
+                                    if (!configTargetSelector.enabled || !configTargetSelector.currentText.startsWith("TX")) {
+                                        return "N/A"
+                                    }
+                                    // Extract module index from "TX 0", "TX 1", etc.
+                                    var parts = configTargetSelector.currentText.split(" ")
+                                    if (parts.length >= 2) {
+                                        var moduleIndex = parseInt(parts[1])
+                                        return modules[moduleIndex] ? modules[moduleIndex].firmwareVersion : "N/A"
+                                    }
+                                    return "N/A"
+                                }
+                                color: "#2ECC71"
+                                font.pixelSize: 12
+                            }
+                        }
+
                         // Read Config
                         Rectangle {
                             Layout.fillWidth: true
@@ -460,6 +551,34 @@ Rectangle {
                                 onClicked: {
                                     var target = configTargetSelector.currentText.toLowerCase()
                                     LIFUConnector.readUserConfig(target)
+                                }
+                            }
+
+                            Behavior on color { ColorAnimation { duration: 150 } }
+                        }
+
+                        // Load Test Report
+                        Rectangle {
+                            Layout.fillWidth: true
+                            height: 40
+                            radius: 6
+                            color: testReportArea.containsMouse ? "#F39C12" : "#3A3F4B"
+                            border.color: testReportArea.containsMouse ? "#FFFFFF" : "#BDC3C7"
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: "Load Test Report"
+                                color: "white"
+                                font.pixelSize: 13
+                                font.weight: Font.Medium
+                            }
+
+                            MouseArea {
+                                id: testReportArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onClicked: {
+                                    testReportDialog.open()
                                 }
                             }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     "pyserial>=3.5",
     "soundfile>=0.12.0",
     "sounddevice>=0.4.6",
-    "openlifu-sdk>=1.0.1"
+    "openlifu-sdk>=1.0.2",
+    "openpyxl"
 ]
 
 [project.optional-dependencies]

--- a/scripts/test_reports.py
+++ b/scripts/test_reports.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import json
+import re
+import pandas as pd
+import xarray as xa
+import datetime
+import logging
+
+FOCAL_GAIN_LUT = xa.DataArray.from_dict(
+    {'dims': ('f0', 'crosstalk'),
+ 'attrs': {},
+ 'data': [[2.807589054107666,
+   3.2286391258239746,
+   3.649686813354492,
+   3.8181092739105225,
+   4.07073974609375,
+   4.491786956787109,
+   4.912837505340576,
+   5.333885669708252,
+   5.754938125610352,
+   6.175983428955078,
+   6.597033500671387,
+   7.01808500289917],
+  [2.90433931350708,
+   3.3324313163757324,
+   3.760524272918701,
+   3.931760549545288,
+   4.188616752624512,
+   4.616710662841797,
+   5.044803142547607,
+   5.472893714904785,
+   5.900986671447754,
+   6.3290791511535645,
+   6.757172107696533,
+   7.185482501983643],
+  [2.9909276962280273,
+   3.428293466567993,
+   3.865659713745117,
+   4.040605068206787,
+   4.3030242919921875,
+   4.740390777587891,
+   5.1777544021606445,
+   5.615119934082031,
+   6.052487373352051,
+   6.489851951599121,
+   6.927217483520508,
+   7.364583969116211],
+  [3.0771772861480713,
+   3.5201354026794434,
+   3.9643561840057373,
+   4.142045497894287,
+   4.408576965332031,
+   4.852799415588379,
+   5.297021865844727,
+   5.741242408752441,
+   6.185462474822998,
+   6.629685878753662,
+   7.073910713195801,
+   7.518129348754883],
+  [3.170368194580078,
+   3.617199182510376,
+   4.064029693603516,
+   4.242762565612793,
+   4.51104211807251,
+   4.961826801300049,
+   5.4126152992248535,
+   5.863399505615234,
+   6.314184665679932,
+   6.764969825744629,
+   7.215755462646484,
+   7.666543960571289],
+  [3.242729663848877,
+   3.6979565620422363,
+   4.153182506561279,
+   4.335274696350098,
+   4.6084089279174805,
+   5.064931869506836,
+   5.521984100341797,
+   5.979033946990967,
+   6.4360833168029785,
+   6.89313268661499,
+   7.350184440612793,
+   7.8072357177734375],
+  [3.327850103378296,
+   3.783803701400757,
+   4.245124340057373,
+   4.429731845855713,
+   4.706640720367432,
+   5.168155193328857,
+   5.6296706199646,
+   6.091186046600342,
+   6.552703380584717,
+   7.014214992523193,
+   7.475728988647461,
+   7.937244415283203],
+  [3.415055990219116,
+   3.8783867359161377,
+   4.341715335845947,
+   4.527048110961914,
+   4.8050456047058105,
+   5.268375396728516,
+   5.731706142425537,
+   6.195037841796875,
+   6.658364295959473,
+   7.12183952331543,
+   7.587955474853516,
+   8.054073333740234],
+  [5.705652713775635,
+   5.966911792755127,
+   6.2332234382629395,
+   6.343565940856934,
+   6.509076118469238,
+   6.784928798675537,
+   7.060781478881836,
+   7.336633682250977,
+   7.612486362457275,
+   7.888339519500732,
+   8.164192199707031,
+   8.447998046875],
+  [5.73893404006958,
+   5.998416423797607,
+   6.260423183441162,
+   6.365228652954102,
+   6.522432327270508,
+   6.784440994262695,
+   7.046449184417725,
+   7.310236930847168,
+   7.583878517150879,
+   7.8575215339660645,
+   8.131163597106934,
+   8.404805183410645],
+  [5.780664920806885,
+   6.028132915496826,
+   6.275601387023926,
+   6.3745880126953125,
+   6.523068904876709,
+   6.777853965759277,
+   7.03900146484375,
+   7.300150394439697,
+   7.561298370361328,
+   7.822445869445801,
+   8.083595275878906,
+   8.350235939025879],
+  [5.814091205596924,
+   6.0464091300964355,
+   6.284290313720703,
+   6.383488178253174,
+   6.532283306121826,
+   6.780277252197266,
+   7.028269290924072,
+   7.27626371383667,
+   7.524255752563477,
+   7.772250175476074,
+   8.040055274963379,
+   8.318523406982422],
+  [5.836524486541748,
+   6.067535400390625,
+   6.301788806915283,
+   6.3954901695251465,
+   6.536042213439941,
+   6.770293712615967,
+   7.00454568862915,
+   7.238796710968018,
+   7.482921600341797,
+   7.740076541900635,
+   8.005291938781738,
+   8.270505905151367],
+  [5.86801815032959,
+   6.0880255699157715,
+   6.308032989501953,
+   6.396038055419922,
+   6.528041839599609,
+   6.749823093414307,
+   6.9840264320373535,
+   7.218224048614502,
+   7.4528584480285645,
+   7.70409631729126,
+   7.955334663391113,
+   8.206572532653809],
+  [5.892360210418701,
+   6.097702980041504,
+   6.303044319152832,
+   6.390904903411865,
+   6.523708343505859,
+   6.7450480461120605,
+   6.966385841369629,
+   7.187726020812988,
+   7.417387962341309,
+   7.661881923675537,
+   7.91318941116333,
+   8.164498329162598],
+  [5.90617036819458,
+   6.104805946350098,
+   6.312875747680664,
+   6.396102428436279,
+   6.520944595336914,
+   6.729012966156006,
+   6.937082290649414,
+   7.15734338760376,
+   7.39542818069458,
+   7.6335129737854,
+   7.8715996742248535,
+   8.1096830368042]],
+ 'coords': {'f0': {'dims': ('f0',),
+   'attrs': {},
+   'data': [130000.0,
+    135000.0,
+    140000.0,
+    145000.0,
+    150000.0,
+    155000.0,
+    160000.0,
+    165000.0,
+    375000.0,
+    380000.0,
+    385000.0,
+    390000.0,
+    395000.0,
+    400000.0,
+    405000.0,
+    410000.0]},
+  'crosstalk': {'dims': ('crosstalk',),
+   'attrs': {},
+   'data': [0.0,
+    0.05,
+    0.1,
+    0.12,
+    0.15000000000000002,
+    0.2,
+    0.25,
+    0.30000000000000004,
+    0.35000000000000003,
+    0.4,
+    0.45,
+    0.5]}},
+ 'name': 'focal_gain'})
+
+ROW_SDK_VER = 'A.4'
+ROW_SN = 'B.1'
+ROW_FREQ = 'B.2'
+ROW_HW_VER = 'B.3'
+ROW_HWID = 'B.4'
+ROW_FW_VER = 'B.5'
+ROW_VOLTAGE = 'E.1'
+
+logger = logging.getLogger(__name__)
+
+def read_test_report(filename: str) -> pd.DataFrame:
+    sections = [{"name": "info", "start_row": "A"},
+                {"name": "txm", "start_row": "B"},
+                {"name": "console", "start_row": "C"},
+                {"name": "scans", "start_row": "D"},
+                {"name": "freq", "start_row": "E"},
+                {"name": "voltage", "start_row": "F"}]
+    raw = pd.read_excel(filename, sheet_name="Report", header=None, usecols="A").rename({0: "Index"}, axis=1)
+    all_data = []
+    for section in sections:
+        skiprows = raw.loc[raw["Index"] == section["start_row"]].index[0]+1
+        nrows = raw['Index'].str.startswith(f'{section["start_row"]}.').sum()
+        report_df = pd.read_excel(filename, sheet_name="Report", skiprows=skiprows, nrows=nrows, index_col=0, usecols="A:C")
+        report_df["Section"] = section["name"]
+        all_data.append(report_df)
+
+    report_df = pd.concat(all_data)
+    return report_df
+
+def report_to_matrix_dict(report_df: pd.DataFrame, focal_gain_lut=FOCAL_GAIN_LUT) -> dict:
+    LIFU_400 = {'id': r'txm_400_{sn}', 'name': r'TXM 400kHz (S/N {sn})', 'nx': 8, 'ny': 8, 'pitch': 5, 'frequency': 400e3, 'kerf': 0.3, 'crosstalk_frac': 0.12, 'crosstalk_dist': 5.05e-3}
+    LIFU_155 = {'id': r'txm_155_{sn}', 'name': r'TXM 155kHz (S/N {sn})', 'nx': 8, 'ny': 8, 'pitch': 5, 'frequency': 155e3, 'kerf': 0.3, 'crosstalk_frac': 0.12, 'crosstalk_dist': 5.05e-3}
+    LIFU_MODULES = {400: LIFU_400, 155: LIFU_155}
+    freq_kHz = report_df.loc[ROW_FREQ]["Value"]
+    voltage = report_df.loc[ROW_VOLTAGE]["Value"]
+    sn = report_df.loc[ROW_SN]["Value"]
+    pattern = r'[^a-zA-Z0-9\-\_]'
+    replacement = ''
+    sn = re.sub(pattern, replacement, sn)
+    matrix_dict = LIFU_MODULES[freq_kHz]
+    freq_df = report_df[report_df["Section"] == "freq"].copy().drop(columns=["Section"])
+    freq_df = freq_df.rename(columns={"Value": "PNP"})
+    freq_df = freq_df[freq_df['Item'].str.startswith("PNP")]
+    freq_df["Frequency"] = freq_df['Item'].apply(lambda x: float(re.search(r"(?<=^PNP \()\d+(?= kHz\)$)", x).group(0)))
+    freq_df['focal_gain'] = freq_df['Frequency'].apply(lambda f: focal_gain_lut.interp(f0=f*1e3, crosstalk=matrix_dict['crosstalk_frac']).item())
+    freq_df['Sensitivity'] = freq_df['PNP'].astype(float)*1e6/freq_df['focal_gain']/voltage
+    matrix_dict['sensitivity'] = {'freq_Hz':[float(f)*1e3 for f in freq_df['Frequency']],
+                                  'values_Pa_per_V':[float(sens) for sens in freq_df['Sensitivity']]}
+    matrix_dict['id'] = matrix_dict['id'].format(sn=sn.lower())
+    matrix_dict['name'] = matrix_dict['name'].format(sn=sn)
+    return matrix_dict
+
+def test_report_to_config(report_df):
+    matrix_dict = report_to_matrix_dict(report_df)
+    now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    sdk_version = report_df.loc[ROW_SDK_VER]['Value']
+    sn = report_df.loc[ROW_SN]['Value']
+    freq = report_df.loc[ROW_FREQ]['Value']
+    hw_version = report_df.loc[ROW_HW_VER]['Value']
+    hwid = report_df.loc[ROW_HWID]['Value']
+    fw_version = report_df.loc[ROW_FW_VER]['Value']
+    config = {'sn': sn,
+              'hwid': hwid,
+              'freq': freq,
+              'hw_version': hw_version,
+              'fw_version': fw_version,
+              'sdk_version': sdk_version,
+              'last_updated': now,
+              'module': matrix_dict,
+              'device':{}}
+    return config
+
+def check_config_against_device(ifx, config, module=0):
+    sdk_version = ifx.get_sdk_version()
+    if sdk_version != config['sdk_version']:
+        logger.warning(f"SDK version of the config {config['sdk_version']} does not match the current SDK version {sdk_version}")
+    fw_version = ifx.txdevice.get_version(module)
+    if fw_version != config['fw_version']:
+        logger.warning(f"Firmware version of the config ({config['fw_version']}) does not match the version of the device ({fw_version})")
+        return False
+    hwid = ifx.txdevice.get_hardware_id(module)
+    if hwid != config['hwid']:
+        logger.warning(f"Hardware ID of the config ({config['hwid']}) does not match the ID of the device ({hwid})")
+        return False
+    return True


### PR DESCRIPTION
Improvements to `Settings`:
- Adds the ability to load an excel-based report from file into the Settings page.
- Adds selectable indicators of hw and fw version to the Settings page, and makes the App and SDK versions in the titlebar selectable for ready copying into the report
Improvements to `Demo`:
- Adds TX temperature and HV ADC display and polling to the System Status box
- Adds control enable logic to clearly show when the UI controls can be edited, and lock them from editing until you click "edit solution", which also resets device status.
- Updates the TX/HV indicator colors
- Makes the System status text pulse green while the system is in the `RUNNING` state